### PR TITLE
Fix bug that prevented downloading f32 tensors

### DIFF
--- a/tensor_downloader.sh
+++ b/tensor_downloader.sh
@@ -353,7 +353,7 @@ do_huggingface() {
     if [ $? -eq 0 ]; then
       log "Download complete, verifying…"
       if verify_download "${DST}"; then
-        log "✓ Verified and saved via huggingface (org: ${ORG}, banch: ${BRANCH}) - ${DST} (${QUANT_U})"
+        log "✓ Verified and saved via huggingface (org: ${ORG}, branch: ${BRANCH}) - ${DST} (${QUANT_U})"
         chmod 444 "${DST}"
         return 0
       else


### PR DESCRIPTION
Not sure why noone was reporting this bug so far.
3874964 broke f32 tensors downloading, making it impossible to download f32 shards.
F32 tensors don't have their own tensors.f32.map, and they are loaded from tensors.bf16.map, but that old commit forbids reusing map files, thus introducing the bug.
I've altered flow to allow reusing the data without re-downloading it.
